### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @softservedata


### PR DESCRIPTION
This CODEOWNERS file will configure GitHub to designate softservedata as the code owner for all files matching the specified patterns in the main branch. 